### PR TITLE
Add gamification mechanics to planner

### DIFF
--- a/calories calculator.html
+++ b/calories calculator.html
@@ -6,6 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no"/>
   <title>Calorie & Activity Planner</title>
 
+  <!-- Gamified: coins, hearts, XP, daily quests & spin wheel -->
   <!-- Tailwind -->
   <script src="https://cdn.tailwindcss.com"></script>
   <!-- Icons -->
@@ -29,6 +30,21 @@
     .modal-overlay { overscroll-behavior: contain; -webkit-overflow-scrolling: touch; }
     .modal-card-scroll { max-height: 90dvh; overflow-y: auto; -webkit-overflow-scrolling: touch; }
     .body-locked { position: fixed; overflow: hidden; width: 100%; }
+
+    /* --- Gamification visuals --- */
+    #wheel {
+      width: 10rem; height: 10rem; margin:auto; border-radius:50%;
+      border:4px solid #cbd5e1;
+      background:conic-gradient(#fde68a 0deg 90deg,#fcd34d 90deg 180deg,#fbbf24 180deg 270deg,#fcd34d 270deg 360deg);
+    }
+    #wheel.spin { transition:transform 1s ease-out; }
+    #spinPointer {
+      position:absolute; top:-6px; left:50%; transform:translateX(-50%);
+      width:0;height:0;border-left:8px solid transparent;border-right:8px solid transparent;border-bottom:12px solid #ef4444;
+    }
+    #spinBtnInner{pointer-events:none}
+    .quest-btn{transition:.2s}
+    .quest-btn:disabled{opacity:.5;cursor:not-allowed}
   </style>
 </head>
 
@@ -41,6 +57,11 @@
       <p class="text-gray-600">Personal results, saved profile, and your activity plan</p>
     </div>
     <div class="flex items-center gap-2">
+      <div class="flex items-center gap-3 mr-2 text-sm">
+        <div class="flex items-center text-yellow-600"><i class="fa-solid fa-coins mr-1"></i><span id="coinsDisplay">0</span></div>
+        <div class="flex items-center text-red-500"><i class="fa-solid fa-heart mr-1"></i><span id="heartsDisplay">0</span></div>
+        <div class="flex items-center text-blue-600"><i class="fa-solid fa-star mr-1"></i><span id="levelDisplay">1</span></div>
+      </div>
       <span id="goalBadge" class="badge hidden"></span>
       <button id="openProfile" class="px-3 py-2 border border-gray-300 rounded-lg hover:bg-white">
         <i class="fa-solid fa-user-gear mr-2"></i>Profile
@@ -118,6 +139,24 @@
       <div class="bg-white rounded-xl shadow p-5">
         <div class="flex items-center mb-2"><i class="fa-solid fa-list-check mr-3 text-purple-600"></i><div class="font-semibold">Today’s plan</div></div>
         <div id="todayPlan" class="text-sm text-gray-600">—</div>
+      </div>
+    </div>
+
+    <!-- Gamification widgets -->
+    <div class="mt-6 grid grid-cols-1 md:grid-cols-2 gap-4">
+      <div class="bg-white rounded-xl shadow p-5">
+        <div class="flex items-center mb-2"><i class="fa-solid fa-arrows-rotate mr-3 text-pink-600"></i><div class="font-semibold">Daily Spin</div></div>
+        <div class="relative w-40 h-40 mx-auto mb-4">
+          <div id="spinPointer"></div>
+          <div id="wheel"></div>
+          <button id="spinBtn" class="absolute inset-0 m-auto w-16 h-16 bg-indigo-600 text-white rounded-full" onclick="spinWheel()"><span id="spinBtnInner">Spin</span></button>
+        </div>
+        <div id="spinResult" class="text-sm text-indigo-600 font-semibold text-center"></div>
+        <div id="spinInfo" class="text-xs text-gray-500 mt-1 text-center"></div>
+      </div>
+      <div class="bg-white rounded-xl shadow p-5">
+        <div class="flex items-center mb-2"><i class="fa-solid fa-list-check mr-3 text-green-600"></i><div class="font-semibold">Daily Quests</div></div>
+        <ul id="questsList" class="text-sm text-gray-600 space-y-2"></ul>
       </div>
     </div>
   </div>
@@ -427,6 +466,7 @@
 <script>
   const $ = (s) => document.querySelector(s);
   const LS_PROFILE='cap.profile', LS_SCHEDULE='cap.schedule', LS_LOGS='cap.logs';
+  const LS_GAME='cap.game', LS_QUESTS='cap.dailyQuests';
   const kcalPerKg = 7700;
   const WEEK=['Mon','Tue','Wed','Thu','Fri','Sat','Sun'];
 
@@ -456,6 +496,102 @@
   function saveSchedule(s){ localStorage.setItem(LS_SCHEDULE, JSON.stringify(s||{})); }
   function getLogs(){ try{ return JSON.parse(localStorage.getItem(LS_LOGS)||'[]'); }catch(e){ return []; } }
   function saveLogs(a){ localStorage.setItem(LS_LOGS, JSON.stringify(a||[])); }
+
+  function loadGame(){
+    try{ return Object.assign({coins:0, hearts:5, xp:0, level:1, streak:0, lastLogin:null, nextFreeSpinAt:0}, JSON.parse(localStorage.getItem(LS_GAME)||'{}')); }
+    catch(e){ return {coins:0, hearts:5, xp:0, level:1, streak:0, lastLogin:null, nextFreeSpinAt:0}; }
+  }
+  function saveGame(g){ localStorage.setItem(LS_GAME, JSON.stringify(g||{})); }
+  function loadQuests(){
+    try{ const q=JSON.parse(localStorage.getItem(LS_QUESTS)||'{}'); const today=localISO(); if(q.date!==today) return {date:today, completed:[]}; return q; }
+    catch(e){ return {date:localISO(), completed:[]}; }
+  }
+  function saveQuests(q){ localStorage.setItem(LS_QUESTS, JSON.stringify(q||{})); }
+
+  let game = loadGame();
+  let dailyQuests = loadQuests();
+  const QUEST_DEFS=[
+    {id:'log', text:'Log an activity'},
+    {id:'schedule', text:'Open Training Schedule'},
+    {id:'spin', text:'Use daily spin'}
+  ];
+
+  function addCoins(n){ game.coins += n; saveGame(game); renderGameStatus(); }
+  function addHearts(n){ game.hearts = Math.max(0, game.hearts + n); saveGame(game); renderGameStatus(); }
+  function addXP(n){
+    game.xp += n;
+    while(game.xp >= game.level*100){ game.xp -= game.level*100; game.level++; }
+    saveGame(game); renderGameStatus();
+  }
+  function renderGameStatus(){
+    $('#coinsDisplay').textContent = game.coins;
+    $('#heartsDisplay').textContent = game.hearts;
+    $('#levelDisplay').textContent = `Lv ${game.level}`;
+  }
+  function renderQuests(){
+    const list=$('#questsList'); if(!list) return;
+    list.innerHTML='';
+    QUEST_DEFS.forEach(q=>{
+      const done=dailyQuests.completed.includes(q.id);
+      const li=document.createElement('li');
+      li.className='flex items-center justify-between';
+      const span=document.createElement('span'); span.textContent=q.text; li.appendChild(span);
+      const btn=document.createElement('button');
+      btn.className='quest-btn text-xs px-2 py-1 rounded '+(done?'bg-green-200 text-green-700':'bg-indigo-200 text-indigo-700');
+      btn.textContent=done?'Done':'Complete';
+      btn.disabled=done;
+      btn.addEventListener('click',()=>recordQuest(q.id));
+      li.appendChild(btn);
+      list.appendChild(li);
+    });
+  }
+  function recordQuest(id){
+    if(!dailyQuests.completed.includes(id)){
+      dailyQuests.completed.push(id);
+      saveQuests(dailyQuests);
+      addCoins(5); addXP(5);
+      renderQuests();
+    }
+  }
+
+  function handleDailyLogin(){
+    const today=localISO();
+    if(game.lastLogin!==today){
+      if(game.lastLogin && daysBetweenLocal(game.lastLogin, today)===1){ game.streak++; } else { game.streak=1; }
+      game.lastLogin=today;
+      saveGame(game);
+      dailyQuests={date:today, completed:[]}; saveQuests(dailyQuests);
+      addCoins(10); addXP(10);
+    }
+  }
+  function canSpin(){ return Date.now() >= (game.nextFreeSpinAt||0); }
+  function updateSpinInfo(){
+    const info=$('#spinInfo'); if(!info) return;
+    if(canSpin()){ info.textContent='Ready'; $('#spinBtn').disabled=false; }
+    else { const ms=game.nextFreeSpinAt-Date.now(); const h=Math.ceil(ms/3600000); info.textContent=`Come back in ${h}h`; $('#spinBtn').disabled=true; }
+  }
+  function spinWheel(){
+    if(!canSpin()) return;
+    const wheel=$('#wheel'); const btn=$('#spinBtn'); const result=$('#spinResult');
+    const rewards=[
+      {type:'coins',amount:5,text:'+5 Coins',angle:45},
+      {type:'coins',amount:10,text:'+10 Coins',angle:135},
+      {type:'coins',amount:20,text:'+20 Coins',angle:225},
+      {type:'hearts',amount:1,text:'+1 Heart',angle:315}
+    ];
+    const r=rewards[Math.floor(Math.random()*rewards.length)];
+    const rotation=720+r.angle; // two full spins + landing angle
+    wheel.classList.add('spin');
+    wheel.style.transform=`rotate(${rotation}deg)`;
+    btn.disabled=true;
+    setTimeout(()=>{
+      if(r.type==='coins') addCoins(r.amount); else addHearts(r.amount);
+      result.textContent=`You won ${r.text}!`;
+      game.nextFreeSpinAt=Date.now()+24*3600*1000; saveGame(game); updateSpinInfo();
+      recordQuest('spin');
+      btn.disabled=false;
+    },1000);
+  }
 
   /* ===== Badge ===== */
   function updateGoalBadge(goalType){ const map = {lose:'Lose', maintain:'Maintain', gain:'Gain'}; const el = $('#goalBadge'); el.textContent = map[goalType] || 'Goal'; el.classList.remove('hidden'); }
@@ -816,6 +952,7 @@
     const logs=getLogs(); logs.push({id:Date.now(), date:d, type:t, amount:a, kcal});
     saveLogs(logs); $('#logAmount').value='';
     renderLog(); updateProgressBar(); renderDailyTargetPanel();
+    addCoins(1); addXP(1); recordQuest('log');
   });
   document.getElementById('btnClearLog').addEventListener('click', ()=>{
     if(confirm('Clear all log entries?')){ saveLogs([]); renderLog(); updateProgressBar(); renderDailyTargetPanel(); }
@@ -997,12 +1134,16 @@
         .forEach((c,i)=>setTimeout(()=>c.classList.add('show'),i*100)),50);
     }
     if(id==='tabLog'){ renderLog(); }
-    if(id==='tabSchedule'){ renderSchedule(); }
+    if(id==='tabSchedule'){ renderSchedule(); recordQuest('schedule'); }
   }
   document.querySelectorAll('.tab-button').forEach(b=>b.addEventListener('click',()=>switchTab(b.id)));
 
   /* ===== Init ===== */
   window.onload = ()=>{
+    handleDailyLogin();
+    renderGameStatus();
+    renderQuests();
+    updateSpinInfo();
     if(!hasProfile()){
       showOnboarding();
     } else {


### PR DESCRIPTION
## Summary
- Display coins, hearts, and level next to profile for quick progress visibility
- Persist coins, hearts, XP, streak, and daily spin timer in localStorage
- Reward daily logins, quests, and wheel spins with coins and XP
- Animate daily spin wheel and add interactive buttons for quests

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad64cb58f4832f9c152f636826b460